### PR TITLE
Fix TagBot workflow to enable package release recognition

### DIFF
--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -33,4 +33,3 @@ jobs:
       - uses: JuliaRegistries/TagBot@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          ssh: ${{ secrets.DOCUMENTER_KEY }}


### PR DESCRIPTION
Remove the ssh/DOCUMENTER_KEY parameter from TagBot workflow which was causing TagBot to fail. This SSH key is only needed for documentation deployment with Documenter.jl and SSH deploy keys. Without this fix, TagBot cannot create release tags when new versions are registered in the Julia General registry, preventing JuliaPackages.com from recognizing new releases.

## Summary by Sourcery

CI:
- Remove the ssh parameter from the TagBot workflow to prevent failure