### PR TITLE
Fix CompatHelper workflow action reference

### DIFF
--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -26,7 +26,7 @@ jobs:
         if: steps.julia_in_path.outcome != 'success'
 
       - name: Run CompatHelper
-        uses: julia-actions/CompatHelper@v3
+        uses: JuliaRegistries/compathelper-action@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           pr_labels: 'dependencies'


### PR DESCRIPTION
Update the CompatHelper action from the deprecated julia-actions/CompatHelper@v3 to the correct JuliaRegistries/compathelper-action@v1. The action has been moved to the JuliaRegistries organization.

This fixes the "repository not found" error in the CompatHelper workflow.

## Summary by Sourcery

Update the CompatHelper GitHub Action reference in the CI workflow to the new JuliaRegistries/compathelper-action@v1 and resolve the repository not found error

Bug Fixes:
- Fix ‘repository not found’ error in the CompatHelper workflow

CI:
- Replace deprecated julia-actions/CompatHelper@v3 with JuliaRegistries/compathelper-action@v1 in the CompatHelper workflow