### PR TITLE
Document breaking changes in CHANGELOG for v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,7 +88,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Breaking Changes
 
-None. All changes are backward compatible.
+⚠️ **Important:** This is a breaking release (0.2.x → 0.3.0)
+
+1. **Return Type Change in Core Functions** (commit 6747b86)
+   - `convolve()` and `group_by_resolution()` now return `Vector{Tuple{Float64, Float64}}` instead of `Vector{Pair{Float64, Float64}}`
+   - **Migration Guide:** If your code relies on the returned values, update pattern matching:
+     ```julia
+     # Old code (may have worked with Pairs):
+     result = convolve(dist1, dist2, cutoff)
+     # Pairs used .first and .second
+
+     # New code (uses Tuples):
+     result = convolve(dist1, dist2, cutoff)
+     # Tuples indexed with [1] and [2], or destructured with (mass, abundance)
+     ```
+   - This change ensures type consistency with declared return types and improves compatibility with newer Julia versions
+
+2. **Exported `Compound` Struct**
+   - The `Compound` struct is now publicly exported
+   - **Impact:** If you have your own `Compound` type defined, you may experience naming conflicts
+   - **Migration Guide:** Either rename your local `Compound` type or use qualified imports:
+     ```julia
+     import IsotopicCalc: isotopicPattern  # Import specific functions without Compound
+     ```
 
 ### Deprecations
 


### PR DESCRIPTION
Updated CHANGELOG.md to properly document the breaking changes in version 0.3.0 as required by JuliaRegistrator AutoMerge guidelines.

Breaking changes documented:
1. Return type change from Pair to Tuple in convolve() and group_by_resolution()
2. Export of Compound struct which may cause naming conflicts

This addresses the issue raised in https://github.com/JuliaRegistries/General/pull/142751 where the registration bot flagged the lack of release notes for the breaking version bump.

With these documented breaking changes, the package can be re-registered with proper release notes to satisfy AutoMerge requirements.

## Summary by Sourcery

Document breaking changes in CHANGELOG for v0.3.0 to meet JuliaRegistrator AutoMerge guidelines

Documentation:
- Add breaking change entry for convolve() and group_by_resolution() returning Tuples instead of Pairs
- Add breaking change entry for publicly exported Compound struct to highlight potential naming conflicts