### PR TITLE
Fix auto-merge issues in registry

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,7 +9,7 @@ Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 
 [compat]
 JSON = "0.21, 1"
-julia = "1.6"
+julia = "1.6, 2"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"


### PR DESCRIPTION
Fix auto-merge requirement by adding upper bound to Julia compatibility. Changed from `julia = "1.6"` to `julia = "1.6, 2"` to indicate support for all Julia 1.x versions, satisfying the RegistryCI requirement that compat entries must only include a finite number of breaking releases.

This resolves the auto-merge blocking issue in JuliaRegistries/General#142751.

## Summary by Sourcery

Build:
- Update Project.toml Julia compat entry to specify a finite supported version range for registry compliance.