### PR TITLE
Breaking changes: Unify API and function naming conventions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,65 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.0] - TBD
+
+### Breaking Changes
+
+⚠️ **This is a major breaking release with API changes**
+
+#### 1. Function Naming Convention Changes
+All exported functions now follow Julia best practices with lowercase and underscores:
+
+| Old Name (v0.3.0) | New Name (v0.4.0) |
+|-------------------|-------------------|
+| `isotopicPattern` | `isotopic_pattern` |
+| `monoisotopicMass` | `monoisotopic_mass` |
+| `isotopicPatternProtonated` | `isotopic_pattern_protonated` |
+| `monoisotopicMassProtonated` | `monoisotopic_mass_protonated` |
+| `findFormula` | `find_formula` |
+
+**Migration:** Update all function calls to use the new lowercase_with_underscores format.
+
+```julia
+# Old code (v0.3.0)
+mass = monoisotopicMass("C3H6O")
+pattern = isotopicPattern("C3H6O")
+results = findFormula(58.0419)
+
+# New code (v0.4.0)
+mass = monoisotopic_mass("C3H6O")
+pattern = isotopic_pattern("C3H6O")
+results = find_formula(58.0419)
+```
+
+#### 2. Adduct API Simplified
+- **Removed backward compatibility** for old adduct format (`"M+H"`, `"M+Na"`, `"M+K"`, `"M-H"`)
+- **Removed `charge` parameter** from `find_formula()` function
+- Only new format is supported: `"H+"`, `"Na+"`, `"K+"`, `"H-"`, `""`
+
+```julia
+# Old code (v0.3.0)
+find_formula(59.0491; adduct="M+H", charge=1)  # No longer works
+
+# New code (v0.4.0)
+find_formula(59.0491; adduct="H+")  # Required format
+```
+
+### Added
+- **`AdductInfo` struct** - New data structure encapsulating adduct mass, charge, and display name
+- **`get_adduct_info()` helper function** - Validates and retrieves adduct information with proper error handling
+
+### Changed
+- **Function naming** - All exported functions renamed to follow Julia conventions (lowercase with underscores)
+- **`find_formula()` signature** - Removed separate `charge` parameter, integrated into `adduct` parameter
+- **Internal API** - `generate_formulas()` now accepts `AdductInfo` instead of separate parameters
+- **Documentation** - Updated all examples to use new naming and adduct format
+- **Tests** - Updated all tests to use new API
+
+### Removed
+- **Old adduct format** - `"M+H"`, `"M+Na"`, `"M+K"`, `"M-H"` no longer supported
+- **`charge` parameter** - Removed from `find_formula()` function
+
 ## [0.3.0] - 2025-11-04
 
 ### Added

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "IsotopicCalc"
 uuid = "5554e927-0bdd-4e37-b621-d0b49d571e7b"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Tomas Mikoviny <tomasmi@uio.no> and contributors"]
 
 [deps]

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ C3D6O           # another notation for fully deuterated acetone
 #### Examples
 Main pupose of this package is to give isotopic pattern distribution for any chemical formula in following fashion:
 ```julia
-julia> isotopicPattern("CH3CHOCH3");
+julia> isotopic_pattern("CH3CHOCH3");
 
 Formula:  C3H6O
 ----------------------------
@@ -66,7 +66,7 @@ Actual output of the function is a `Vector{Tuple{Float64,Float64}}` that contain
 
 The function has several keyword arguments used to customize the output. By default it has cut-off abundance set for 1e-5 as is always shown on function printout. The other keyword arguments include resolution (default value 10000) and possible adduct to the molecule (default set to "").
 ```julia
-isotopicPattern(formula::String; 
+isotopic_pattern(formula::String; 
                 abundance_cutoff=1e-5, 
                 R=4000, 
                 adduct::String="", 
@@ -75,7 +75,7 @@ isotopicPattern(formula::String;
 ```
 It's rather self explaining in following examples:
 ```julia
-julia> isotopicPattern("CH3COCH3"; adduct = "Na+");
+julia> isotopic_pattern("CH3COCH3"; adduct = "Na+");
 
 Formula:  C3H6O.Na+
 ----------------------------
@@ -91,7 +91,7 @@ Mass [amu]     Abundance [%]
 84.0387        0.0067
 Found 8 isotopic masses for 1.0e-5 abundance limit.
 
-julia> isotopicPattern("CH3COCH3"; abundance_cutoff = 1e-8);
+julia> isotopic_pattern("CH3COCH3"; abundance_cutoff = 1e-8);
 
 Formula:  C3H6O
 ----------------------------
@@ -116,7 +116,7 @@ Mass [amu]     Abundance [%]
 62.0557        0.0000046
 Found 17 isotopic masses for 1.0e-8 abundance limit.
 
-julia> isotopicPattern("CH3COCH3"; R=4000);
+julia> isotopic_pattern("CH3COCH3"; R=4000);
 
 Formula:  C3H6O
 ----------------------------
@@ -131,54 +131,45 @@ Mass [amu]     Abundance [%]
 61.049         0.0067
 Found 7 isotopic masses for 1.0e-5 abundance limit.
 ```
-There are one special case implemented. Adduct `H⁺` is called inherently by `isotopicPatternProtonated`. 
+There are one special case implemented. Adduct `H⁺` is called inherently by `isotopic_patternProtonated`. 
 
 
 ### Monotisotopic mass calculation
-For calculation of mono-istopic mass there is also `monoisotopicMass` and `monoisotopicMassProtonated`.
+For calculation of mono-istopic mass there is also `monoisotopic_mass` and `monoisotopic_massProtonated`.
 ```julia
-julia> monoisotopicMass("CH3COCH3")
+julia> monoisotopic_mass("CH3COCH3")
 58.0419
 ```
 
 ### Finding formulas
 Rudimentary determination of compound sum formula from monoisotopic mass is implemented too.
 ```julia
-julia> findFormula(58.0419);
+julia> find_formula(58.0419);
 Matching formulas:
  C3H6O  m/z: 58.041865  ppm: 0.61
  ```
 
-The function has several keyword arguments used to customize the output. 
+The function has several keyword arguments used to customize the output.
 ```julia
-findFormula(mz_input::Float64;
+find_formula(mz_input::Float64;
             atom_pool::Dict{String, Int}=Dict("C"=>20, "H"=>100, "O"=>10, "N"=>10),
             tolerance_ppm::Number=100,
-            adduct::String="",
-            charge::Int=0
+            adduct::String=""
            )
 ```
- By default algorithm searches within an interval of 100 ppm around monoisotopic mass and takes into consideration C, H, O, N to be possible building atoms. The associated numbers mean maximum amount of respective atoms to be considered.
-So far adducts can be one of following `M+H`, `M+Na`, `M+K`, `M-H` and charge is to be expressed separately as in example.
+By default algorithm searches within an interval of 100 ppm around monoisotopic mass and takes into consideration C, H, O, N to be possible building atoms. The associated numbers mean maximum amount of respective atoms to be considered.
+
+Supported adducts include `H+`, `Na+`, `K+`, `H-`, or `""` for neutral molecules. The adduct string now contains both the mass change and charge information, making the API cleaner and more intuitive.
 
 ```julia
-julia> findFormula(46.000; tolerance_ppm=2000, charge=1);
-Matching formulas:
- CH2O2+ m/z: 46.004931  ppm: -107.18
- NO2+   m/z: 45.992355  ppm: 166.23
- N2H2O+ m/z: 46.016164  ppm: -351.27
- CNH4O+ m/z: 46.02874   ppm: -624.4
- N3H4+  m/z: 46.039974  ppm: -868.24
- C2H6O+ m/z: 46.041316  ppm: -897.37
- CN2H6+ m/z: 46.05255   ppm: -1141.08
- C2NH8+ m/z: 46.065126  ppm: -1413.78
- C3H10+ m/z: 46.077702  ppm: -1686.32
-
-
-julia> findFormula(59.0491; adduct="M+H", charge=1);
+julia> find_formula(59.0491; adduct="H+");
 Matching formulas:
  C3H6O  [M+H]+  m/z: 59.049141  ppm: -0.7
  CN3H4  [M+H]+  m/z: 59.047799  ppm: 22.04
+
+julia> find_formula(81.0284; adduct="Na+");
+Matching formulas:
+ C3H6O  [M+Na]+  m/z: 81.028084  ppm: 3.9
 ```
 
 

--- a/src/IsotopicCalc.jl
+++ b/src/IsotopicCalc.jl
@@ -12,11 +12,11 @@ A Julia package for calculating isotopic patterns and monoisotopic masses of che
 - Uses NIST atomic weights and isotopic composition data
 
 # Main Functions
-- [`isotopicPattern`](@ref): Calculate full isotopic distribution
-- [`monoisotopicMass`](@ref): Calculate monoisotopic mass
-- [`findFormula`](@ref): Find formulas matching an m/z value
-- [`isotopicPatternProtonated`](@ref): Convenience function for [M+H]⁺
-- [`monoisotopicMassProtonated`](@ref): Monoisotopic mass of [M+H]⁺
+- [`isotopic_pattern`](@ref): Calculate full isotopic distribution
+- [`monoisotopic_mass`](@ref): Calculate monoisotopic mass
+- [`find_formula`](@ref): Find formulas matching an m/z value
+- [`isotopic_pattern_protonated`](@ref): Convenience function for [M+H]⁺
+- [`monoisotopic_mass_protonated`](@ref): Monoisotopic mass of [M+H]⁺
 - [`Compound`](@ref): Data structure for formula search results
 
 # Example Usage
@@ -24,16 +24,16 @@ A Julia package for calculating isotopic patterns and monoisotopic masses of che
 using IsotopicCalc
 
 # Calculate isotopic pattern for acetone
-isotopicPattern("CH3COCH3")
+isotopic_pattern("CH3COCH3")
 
 # Get monoisotopic mass
-mass = monoisotopicMass("C6H12O6")  # Returns 180.0634
+mass = monoisotopic_mass("C6H12O6")  # Returns 180.0634
 
 # Find formulas matching an m/z value
-matches = findFormula(58.0419; tolerance_ppm=10)
+matches = find_formula(58.0419; tolerance_ppm=10)
 
 # Calculate pattern with adduct
-isotopicPattern("C6H12O6"; adduct="Na+")
+isotopic_pattern("C6H12O6"; adduct="Na+")
 ```
 
 # Formula Notation
@@ -59,6 +59,6 @@ module IsotopicCalc
     include("isotopicPattern.jl")
     include("findFormula.jl")
 
-    export isotopicPattern, monoisotopicMass, isotopicPatternProtonated, monoisotopicMassProtonated, findFormula, Compound
+    export isotopic_pattern, monoisotopic_mass, isotopic_pattern_protonated, monoisotopic_mass_protonated, find_formula, Compound
 
 end # module

--- a/src/isotopicPattern.jl
+++ b/src/isotopicPattern.jl
@@ -335,7 +335,7 @@ function extract_charge(adduct::String)
 end
 
 """
-    isotopicPattern(formula::String; abundance_cutoff=1e-5, R=10000, adduct::String="", print=true)
+    isotopic_pattern(formula::String; abundance_cutoff=1e-5, R=10000, adduct::String="", print=true)
 
 Calculate the isotopic pattern distribution for a given chemical formula.
 
@@ -361,7 +361,7 @@ abundance of each isotopologue.
 
 # Examples
 ```julia
-julia> isotopicPattern("CH3COCH3")
+julia> isotopic_pattern("CH3COCH3")
 Formula:  C3H6O
 ----------------------------
 Mass [amu]     Abundance [%]
@@ -370,10 +370,10 @@ Mass [amu]     Abundance [%]
 59.0452        3.2447
 ...
 
-julia> isotopicPattern("C6H12O6"; abundance_cutoff=1e-3, adduct="Na+")
+julia> isotopic_pattern("C6H12O6"; abundance_cutoff=1e-3, adduct="Na+")
 # Returns distribution for sodium adduct of glucose with 0.1% cutoff
 
-julia> pattern = isotopicPattern("C3H6O"; print=false)
+julia> pattern = isotopic_pattern("C3H6O"; print=false)
 # Returns data without printing (useful for programmatic access)
 ```
 
@@ -388,9 +388,9 @@ julia> pattern = isotopicPattern("C3H6O"; print=false)
   or if abundance_cutoff < 0 or R ≤ 0
 - `ArgumentError`: If unknown element or isotope is specified
 
-See also: [`monoisotopicMass`](@ref), [`isotopicPatternProtonated`](@ref), [`findFormula`](@ref)
+See also: [`monoisotopic_mass`](@ref), [`isotopic_pattern_protonated`](@ref), [`find_formula`](@ref)
 """
-function isotopicPattern(formula::String; abundance_cutoff=1e-5, R=10000, adduct::String="", print=true)  # Default resolution R = 10000
+function isotopic_pattern(formula::String; abundance_cutoff=1e-5, R=10000, adduct::String="", print=true)  # Default resolution R = 10000
   # Validate formula format, abundance cutoff, and mass resolution
   if isempty(strip(formula))
     throw(ArgumentError("Formula cannot be empty. Provide a chemical formula like 'H2O', 'C6H12O6', or 'CH3COOH'."))
@@ -506,30 +506,30 @@ end
 
 # special cases
 """
-    isotopicPatternProtonated(formula::String)
+    isotopic_pattern_protonated(formula::String)
 
 Convenience function to calculate the isotopic pattern for a protonated molecule [M+H]⁺.
 
-This is equivalent to calling `isotopicPattern(formula; adduct="H+")`.
+This is equivalent to calling `isotopic_pattern(formula; adduct="H+")`.
 
 # Arguments
-- `formula::String`: Chemical formula (same format as `isotopicPattern`)
+- `formula::String`: Chemical formula (same format as `isotopic_pattern`)
 
 # Returns
 - `Vector{Tuple{Float64, Float64}}`: Array of (mass, abundance) tuples for [M+H]⁺
 
 # Examples
 ```julia
-julia> isotopicPatternProtonated("C3H6O")
+julia> isotopic_pattern_protonated("C3H6O")
 # Calculates pattern for protonated acetone (m/z 59.049)
 ```
 
-See also: [`isotopicPattern`](@ref), [`monoisotopicMassProtonated`](@ref)
+See also: [`isotopic_pattern`](@ref), [`monoisotopic_mass_protonated`](@ref)
 """
-isotopicPatternProtonated(x) = isotopicPattern(x; adduct="H+")
+isotopic_pattern_protonated(x) = isotopic_pattern(x; adduct="H+")
 
 """
-    monoisotopicMass(formula::String)
+    monoisotopic_mass(formula::String)
 
 Calculate the monoisotopic mass (most abundant isotopic composition) for a given formula.
 
@@ -537,55 +537,55 @@ Returns only the mass of the lowest-mass isotopologue (all lightest isotopes),
 without calculating the full isotopic distribution or printing output.
 
 # Arguments
-- `formula::String`: Chemical formula (same format as `isotopicPattern`)
+- `formula::String`: Chemical formula (same format as `isotopic_pattern`)
 
 # Returns
 - `Float64`: Monoisotopic mass in atomic mass units (amu)
 
 # Examples
 ```julia
-julia> monoisotopicMass("CH3COCH3")
+julia> monoisotopic_mass("CH3COCH3")
 58.0419
 
-julia> monoisotopicMass("C6H12O6")
+julia> monoisotopic_mass("C6H12O6")
 180.0634
 
-julia> monoisotopicMass("[13C]H3COCH3")
+julia> monoisotopic_mass("[13C]H3COCH3")
 59.0452  # One carbon is ¹³C instead of ¹²C
 ```
 
 # Notes
 - This is computationally efficient as it only extracts the first mass peak
 - Uses natural isotopic abundances from NIST database
-- For charged species, use the `adduct` parameter in `isotopicPattern` instead
+- For charged species, use the `adduct` parameter in `isotopic_pattern` instead
 
-See also: [`isotopicPattern`](@ref), [`monoisotopicMassProtonated`](@ref)
+See also: [`isotopic_pattern`](@ref), [`monoisotopic_mass_protonated`](@ref)
 """
-monoisotopicMass(x) = isotopicPattern(x;print=false)[1][1]
+monoisotopic_mass(x) = isotopic_pattern(x;print=false)[1][1]
 
 """
-    monoisotopicMassProtonated(formula::String)
+    monoisotopic_mass_protonated(formula::String)
 
 Calculate the monoisotopic mass of a protonated molecule [M+H]⁺.
 
-Equivalent to calling `isotopicPattern(formula; adduct="H+", print=false)[1][1]`.
+Equivalent to calling `isotopic_pattern(formula; adduct="H+", print=false)[1][1]`.
 Useful for mass spectrometry applications where positive-mode ESI is common.
 
 # Arguments
-- `formula::String`: Chemical formula (same format as `isotopicPattern`)
+- `formula::String`: Chemical formula (same format as `isotopic_pattern`)
 
 # Returns
 - `Float64`: Monoisotopic m/z value for [M+H]⁺ in atomic mass units
 
 # Examples
 ```julia
-julia> monoisotopicMassProtonated("C3H6O")
+julia> monoisotopic_mass_protonated("C3H6O")
 59.049141  # Acetone + proton
 
-julia> monoisotopicMassProtonated("C6H12O6")
+julia> monoisotopic_mass_protonated("C6H12O6")
 181.070646  # Glucose + proton
 ```
 
-See also: [`monoisotopicMass`](@ref), [`isotopicPatternProtonated`](@ref)
+See also: [`monoisotopic_mass`](@ref), [`isotopic_pattern_protonated`](@ref)
 """
-monoisotopicMassProtonated(x) = isotopicPattern(x; adduct="H+", print=false)[1][1]
+monoisotopic_mass_protonated(x) = isotopic_pattern(x; adduct="H+", print=false)[1][1]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,77 +3,77 @@ using Test
 
 @testset "IsotopicCalc.jl" begin
 
-    @testset "monoisotopicMass - Basic Formulas" begin
+    @testset "monoisotopic_mass - Basic Formulas" begin
         # Test simple molecules (tolerance accounts for R=10000 resolution rounding)
-        @test isapprox(monoisotopicMass("H2O"), 18.010565, atol=1e-4)
-        @test isapprox(monoisotopicMass("CO2"), 43.989829, atol=1e-4)
-        @test isapprox(monoisotopicMass("CH4"), 16.031300, atol=1e-4)
-        @test isapprox(monoisotopicMass("C3H6O"), 58.041865, atol=1e-4)  # Acetone
-        @test isapprox(monoisotopicMass("C6H12O6"), 180.063388, atol=1e-3)  # Glucose
+        @test isapprox(monoisotopic_mass("H2O"), 18.010565, atol=1e-4)
+        @test isapprox(monoisotopic_mass("CO2"), 43.989829, atol=1e-4)
+        @test isapprox(monoisotopic_mass("CH4"), 16.031300, atol=1e-4)
+        @test isapprox(monoisotopic_mass("C3H6O"), 58.041865, atol=1e-4)  # Acetone
+        @test isapprox(monoisotopic_mass("C6H12O6"), 180.063388, atol=1e-3)  # Glucose
 
         # Test single atoms
-        @test isapprox(monoisotopicMass("C"), 12.0, atol=1e-4)
-        @test isapprox(monoisotopicMass("H"), 1.007825, atol=1e-5)
-        @test isapprox(monoisotopicMass("O"), 15.994915, atol=1e-4)
-        @test isapprox(monoisotopicMass("N"), 14.003074, atol=1e-4)
+        @test isapprox(monoisotopic_mass("C"), 12.0, atol=1e-4)
+        @test isapprox(monoisotopic_mass("H"), 1.007825, atol=1e-5)
+        @test isapprox(monoisotopic_mass("O"), 15.994915, atol=1e-4)
+        @test isapprox(monoisotopic_mass("N"), 14.003074, atol=1e-4)
     end
 
-    @testset "monoisotopicMass - Parentheses Expansion" begin
+    @testset "monoisotopic_mass - Parentheses Expansion" begin
         # Test equivalent formulas with parentheses
-        @test isapprox(monoisotopicMass("(CH3)2CO"), monoisotopicMass("C3H6O"), atol=1e-6)
-        @test isapprox(monoisotopicMass("Ca(OH)2"), monoisotopicMass("CaO2H2"), atol=1e-6)
-        @test isapprox(monoisotopicMass("CH3COCH3"), monoisotopicMass("C3H6O"), atol=1e-6)
+        @test isapprox(monoisotopic_mass("(CH3)2CO"), monoisotopic_mass("C3H6O"), atol=1e-6)
+        @test isapprox(monoisotopic_mass("Ca(OH)2"), monoisotopic_mass("CaO2H2"), atol=1e-6)
+        @test isapprox(monoisotopic_mass("CH3COCH3"), monoisotopic_mass("C3H6O"), atol=1e-6)
 
         # Test nested parentheses
-        @test isapprox(monoisotopicMass("((CH3)2)2"), monoisotopicMass("C4H12"), atol=1e-6)
+        @test isapprox(monoisotopic_mass("((CH3)2)2"), monoisotopic_mass("C4H12"), atol=1e-6)
 
         # Test multiple groups
-        @test isapprox(monoisotopicMass("(CH2)3"), monoisotopicMass("C3H6"), atol=1e-6)
+        @test isapprox(monoisotopic_mass("(CH2)3"), monoisotopic_mass("C3H6"), atol=1e-6)
     end
 
-    @testset "monoisotopicMass - Isotope Specifications" begin
+    @testset "monoisotopic_mass - Isotope Specifications" begin
         # Test specific isotopes
-        c12_mass = monoisotopicMass("C")
-        c13_mass = monoisotopicMass("[13C]")
+        c12_mass = monoisotopic_mass("C")
+        c13_mass = monoisotopic_mass("[13C]")
         @test c13_mass > c12_mass  # 13C should be heavier
         @test isapprox(c13_mass - c12_mass, 1.003355, atol=1e-4)  # Mass difference
 
         # Test deuterium
-        h_mass = monoisotopicMass("H")
-        d_mass = monoisotopicMass("[2H]")
+        h_mass = monoisotopic_mass("H")
+        d_mass = monoisotopic_mass("[2H]")
         @test d_mass > h_mass
         @test isapprox(d_mass - h_mass, 1.006277, atol=1e-4)
 
         # Test D shorthand for deuterium
-        @test isapprox(monoisotopicMass("D"), monoisotopicMass("[2H]"), atol=1e-6)
-        @test isapprox(monoisotopicMass("C3D6O"), monoisotopicMass("C3[2H]6O"), atol=1e-6)
+        @test isapprox(monoisotopic_mass("D"), monoisotopic_mass("[2H]"), atol=1e-6)
+        @test isapprox(monoisotopic_mass("C3D6O"), monoisotopic_mass("C3[2H]6O"), atol=1e-6)
 
         # Test mixed isotopes
-        acetone_normal = monoisotopicMass("C3H6O")
-        acetone_13C = monoisotopicMass("[13C]C2H6O")
+        acetone_normal = monoisotopic_mass("C3H6O")
+        acetone_13C = monoisotopic_mass("[13C]C2H6O")
         @test isapprox(acetone_13C - acetone_normal, 1.003355, atol=1e-4)
     end
 
-    @testset "monoisotopicMassProtonated" begin
+    @testset "monoisotopic_mass_protonated" begin
         # Test protonated masses
-        acetone = monoisotopicMass("C3H6O")
-        acetone_protonated = monoisotopicMassProtonated("C3H6O")
+        acetone = monoisotopic_mass("C3H6O")
+        acetone_protonated = monoisotopic_mass_protonated("C3H6O")
         @test acetone_protonated > acetone
         @test isapprox(acetone_protonated - acetone, 1.007825, atol=1e-3)  # Proton mass (relaxed tolerance due to double rounding)
 
-        # Compare with direct isotopicPattern call
-        pattern_h = isotopicPattern("C3H6O"; adduct="H+", print=false)
-        @test isapprox(monoisotopicMassProtonated("C3H6O"), pattern_h[1][1], atol=1e-6)
+        # Compare with direct isotopic_pattern call
+        pattern_h = isotopic_pattern("C3H6O"; adduct="H+", print=false)
+        @test isapprox(monoisotopic_mass_protonated("C3H6O"), pattern_h[1][1], atol=1e-6)
     end
 
-    @testset "isotopicPattern - Basic Functionality" begin
+    @testset "isotopic_pattern - Basic Functionality" begin
         # Test that function returns expected data structure
-        pattern = isotopicPattern("CH4"; print=false)
+        pattern = isotopic_pattern("CH4"; print=false)
         @test isa(pattern, Vector{Tuple{Float64, Float64}})
         @test length(pattern) >= 1
 
         # First peak should be monoisotopic mass
-        @test isapprox(pattern[1][1], monoisotopicMass("CH4"), atol=1e-6)
+        @test isapprox(pattern[1][1], monoisotopic_mass("CH4"), atol=1e-6)
 
         # Most abundant peak should have abundance 1.0
         abundances = [a for (m, a) in pattern]
@@ -84,42 +84,42 @@ using Test
         @test issorted(masses)
     end
 
-    @testset "isotopicPattern - Adducts" begin
+    @testset "isotopic_pattern - Adducts" begin
         # Test with different adducts
-        base_mass = monoisotopicMass("C3H6O")
+        base_mass = monoisotopic_mass("C3H6O")
 
         # H+ adduct
-        pattern_h = isotopicPattern("C3H6O"; adduct="H+", print=false)
+        pattern_h = isotopic_pattern("C3H6O"; adduct="H+", print=false)
         @test isapprox(pattern_h[1][1] - base_mass, 1.007825, atol=1e-3)  # Relaxed tolerance due to double rounding
 
         # Na+ adduct
-        pattern_na = isotopicPattern("C3H6O"; adduct="Na+", print=false)
+        pattern_na = isotopic_pattern("C3H6O"; adduct="Na+", print=false)
         @test isapprox(pattern_na[1][1] - base_mass, 22.989769, atol=1e-3)  # Relaxed tolerance due to double rounding
 
         # K+ adduct
-        pattern_k = isotopicPattern("C3H6O"; adduct="K+", print=false)
+        pattern_k = isotopic_pattern("C3H6O"; adduct="K+", print=false)
         @test isapprox(pattern_k[1][1] - base_mass, 38.963706, atol=1e-3)  # Relaxed tolerance due to double rounding
 
         # Note: The adduct system currently only supports adding atoms, not removing them.
         # Deprotonation [M-H]- is not supported. "H-" is interpreted as [M+H]- (add H with negative charge).
     end
 
-    @testset "isotopicPattern - Parameters" begin
+    @testset "isotopic_pattern - Parameters" begin
         # Test abundance cutoff parameter
-        pattern_default = isotopicPattern("C10H20O5"; print=false)
-        pattern_strict = isotopicPattern("C10H20O5"; abundance_cutoff=1e-3, print=false)
+        pattern_default = isotopic_pattern("C10H20O5"; print=false)
+        pattern_strict = isotopic_pattern("C10H20O5"; abundance_cutoff=1e-3, print=false)
         @test length(pattern_strict) <= length(pattern_default)
 
         # Test resolution parameter
-        pattern_high_res = isotopicPattern("C3H6O"; R=100000, print=false)
-        pattern_low_res = isotopicPattern("C3H6O"; R=1000, print=false)
+        pattern_high_res = isotopic_pattern("C3H6O"; R=100000, print=false)
+        pattern_low_res = isotopic_pattern("C3H6O"; R=1000, print=false)
         @test length(pattern_high_res) >= length(pattern_low_res)  # Higher R may resolve more peaks
     end
 
-    @testset "isotopicPattern - Isotope Effects" begin
+    @testset "isotopic_pattern - Isotope Effects" begin
         # Molecules with more carbons should have more M+1 peak
-        c3_pattern = isotopicPattern("C3H6O"; print=false)
-        c10_pattern = isotopicPattern("C10H20O5"; print=false)
+        c3_pattern = isotopic_pattern("C3H6O"; print=false)
+        c10_pattern = isotopic_pattern("C10H20O5"; print=false)
 
         # Find M+1 relative abundance (second peak typically)
         if length(c3_pattern) >= 2 && length(c10_pattern) >= 2
@@ -129,10 +129,10 @@ using Test
         end
     end
 
-    @testset "findFormula - Basic Functionality" begin
+    @testset "find_formula - Basic Functionality" begin
         # Test finding exact mass match
-        mz = monoisotopicMass("C3H6O")
-        matches = findFormula(mz; tolerance_ppm=10, atom_pool=Dict("C"=>5, "H"=>10, "O"=>3))
+        mz = monoisotopic_mass("C3H6O")
+        matches = find_formula(mz; tolerance_ppm=10, atom_pool=Dict("C"=>5, "H"=>10, "O"=>3))
 
         @test length(matches) >= 1
         @test any(c -> c.formula == "C3H6O", matches)
@@ -144,15 +144,13 @@ using Test
         end
     end
 
-    @testset "findFormula - With Adducts" begin
-        # Test the original formula search with adduct
+    @testset "find_formula - With Adducts" begin
+        # Test adduct API with H+ format
         mz_input = 33.034
         tolerance = 20.0
         atom_pool = Dict("C" => 5, "H" => 10, "N" => 2, "O" => 3)
-        adduct = "M+H"
-        charge = 1
 
-        results = findFormula(mz_input, tolerance_ppm=tolerance, atom_pool=atom_pool, adduct=adduct, charge=charge)
+        results = find_formula(mz_input, tolerance_ppm=tolerance, atom_pool=atom_pool, adduct="H+")
         @test length(results) >= 1
         @test any(c -> c.formula == "CH4O", results)
 
@@ -166,12 +164,12 @@ using Test
         end
     end
 
-    @testset "findFormula - Tolerance Filtering" begin
+    @testset "find_formula - Tolerance Filtering" begin
         mz = 58.0419  # Acetone
 
         # Strict tolerance should return fewer results
-        strict = findFormula(mz; tolerance_ppm=5, atom_pool=Dict("C"=>5, "H"=>10, "O"=>3, "N"=>3))
-        loose = findFormula(mz; tolerance_ppm=1000, atom_pool=Dict("C"=>5, "H"=>10, "O"=>3, "N"=>3))
+        strict = find_formula(mz; tolerance_ppm=5, atom_pool=Dict("C"=>5, "H"=>10, "O"=>3, "N"=>3))
+        loose = find_formula(mz; tolerance_ppm=1000, atom_pool=Dict("C"=>5, "H"=>10, "O"=>3, "N"=>3))
 
         @test length(strict) <= length(loose)
     end
@@ -192,30 +190,30 @@ using Test
 
     @testset "Error Handling - Invalid Formulas" begin
         # Test invalid characters
-        @test_throws ArgumentError isotopicPattern("C3H6@#")
-        @test_throws ArgumentError isotopicPattern("ABC123!!")
+        @test_throws ArgumentError isotopic_pattern("C3H6@#")
+        @test_throws ArgumentError isotopic_pattern("ABC123!!")
 
         # Test unbalanced brackets
-        @test_throws ArgumentError isotopicPattern("C3H6(O")
-        @test_throws ArgumentError isotopicPattern("C3H6)O")
-        @test_throws ArgumentError isotopicPattern("((CH3)")
+        @test_throws ArgumentError isotopic_pattern("C3H6(O")
+        @test_throws ArgumentError isotopic_pattern("C3H6)O")
+        @test_throws ArgumentError isotopic_pattern("((CH3)")
 
         # Test invalid parameters
-        @test_throws ArgumentError isotopicPattern("C3H6O"; abundance_cutoff=-0.1)
-        @test_throws ArgumentError isotopicPattern("C3H6O"; R=-100)
-        @test_throws ArgumentError isotopicPattern("C3H6O"; R=0)
+        @test_throws ArgumentError isotopic_pattern("C3H6O"; abundance_cutoff=-0.1)
+        @test_throws ArgumentError isotopic_pattern("C3H6O"; R=-100)
+        @test_throws ArgumentError isotopic_pattern("C3H6O"; R=0)
     end
 
     @testset "Error Handling - Unknown Elements" begin
         # Test unknown element
-        @test_throws ArgumentError isotopicPattern("Xx")  # Xx is not a real element
-        @test_throws ArgumentError isotopicPattern("C3H6Zz")  # Zz is not real
+        @test_throws ArgumentError isotopic_pattern("Xx")  # Xx is not a real element
+        @test_throws ArgumentError isotopic_pattern("C3H6Zz")  # Zz is not real
     end
 
     @testset "Edge Cases - Single Atoms" begin
         # Test all common elements work as single atoms
         for element in ["H", "C", "N", "O", "P", "S", "F", "Cl", "Br", "I"]
-            pattern = isotopicPattern(element; print=false)
+            pattern = isotopic_pattern(element; print=false)
             @test length(pattern) >= 1
             @test pattern[1][2] ≈ 1.0  # Most abundant peak
         end
@@ -223,35 +221,35 @@ using Test
 
     @testset "Edge Cases - Large Molecules" begin
         # Test a moderately large molecule doesn't crash
-        pattern = isotopicPattern("C20H30O10"; print=false)
+        pattern = isotopic_pattern("C20H30O10"; print=false)
         @test length(pattern) >= 1
         @test pattern[1][2] ≈ 1.0
 
         # Test protein-like formula
-        pattern2 = isotopicPattern("C100H150N30O30S2"; abundance_cutoff=1e-3, print=false)
+        pattern2 = isotopic_pattern("C100H150N30O30S2"; abundance_cutoff=1e-3, print=false)
         @test length(pattern2) >= 1
     end
 
     @testset "Edge Cases - Elements with Multiple Digits" begin
         # Test formulas with 2-digit counts
         # Note: These comparisons involve resolution rounding, so we use relaxed tolerance
-        @test isapprox(monoisotopicMass("C10H22"), monoisotopicMass("C") * 10 + monoisotopicMass("H") * 22, atol=1e-3)
-        @test isapprox(monoisotopicMass("C100"), monoisotopicMass("C") * 100, atol=1e-3)
+        @test isapprox(monoisotopic_mass("C10H22"), monoisotopic_mass("C") * 10 + monoisotopic_mass("H") * 22, atol=1e-3)
+        @test isapprox(monoisotopic_mass("C100"), monoisotopic_mass("C") * 100, atol=1e-3)
     end
 
     @testset "Consistency Checks" begin
-        # isotopicPattern and monoisotopicMass should agree
+        # isotopic_pattern and monoisotopic_mass should agree
         formulas = ["H2O", "CO2", "C3H6O", "C6H12O6", "CH3COOH"]
         for formula in formulas
-            pattern = isotopicPattern(formula; print=false)
-            mass_direct = monoisotopicMass(formula)
+            pattern = isotopic_pattern(formula; print=false)
+            mass_direct = monoisotopic_mass(formula)
             @test isapprox(pattern[1][1], mass_direct, atol=1e-6)
         end
 
         # Protonated functions should agree
         @test isapprox(
-            isotopicPatternProtonated("C3H6O")[1][1],
-            monoisotopicMassProtonated("C3H6O"),
+            isotopic_pattern_protonated("C3H6O")[1][1],
+            monoisotopic_mass_protonated("C3H6O"),
             atol=1e-6
         )
     end
@@ -259,7 +257,7 @@ using Test
     @testset "Formula Equivalence" begin
         # Different representations of same molecule should give same mass
         acetone_forms = ["C3H6O", "(CH3)2CO", "CH3COCH3"]
-        masses = [monoisotopicMass(f) for f in acetone_forms]
+        masses = [monoisotopic_mass(f) for f in acetone_forms]
         @test all(m -> isapprox(m, masses[1], atol=1e-6), masses)
     end
 


### PR DESCRIPTION
This is a major breaking release (v0.4.0) that improves the package API by following Julia best practices and simplifying the adduct system.

## Breaking Changes

### 1. Function Naming Convention
All exported functions renamed to follow Julia conventions (lowercase with underscores):
- isotopicPattern → isotopic_pattern
- monoisotopicMass → monoisotopic_mass
- isotopicPatternProtonated → isotopic_pattern_protonated
- monoisotopicMassProtonated → monoisotopic_mass_protonated
- findFormula → find_formula

### 2. Simplified Adduct API
- Removed backward compatibility for old adduct format (M+H, M+Na, M+K, M-H)
- Removed separate `charge` parameter from find_formula()
- Only new format supported: H+, Na+, K+, H-, or ""
- Old: find_formula(mz; adduct="M+H", charge=1)
- New: find_formula(mz; adduct="H+")

## New Features
- Added AdductInfo struct for clean adduct representation
- Added get_adduct_info() helper function with validation

## Updated
- All documentation and examples updated to new API
- All tests updated and backward compatibility tests removed
- Version bumped from 0.3.0 to 0.4.0
- Comprehensive migration guide added to CHANGELOG

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Unify the public API naming with Julia conventions and simplify the adduct handling model while updating tests, docs, and versioning for a new 0.4.0 release.

New Features:
- Introduce AdductInfo struct to represent adduct mass, charge, and display name.
- Add get_adduct_info helper for validated lookup of supported adducts.

Enhancements:
- Rename all exported functions to snake_case (isotopic_pattern, monoisotopic_mass, isotopic_pattern_protonated, monoisotopic_mass_protonated, find_formula).
- Refactor formula search to use AdductInfo instead of separate adduct and charge arguments and to derive output formatting from this struct.

Documentation:
- Update README, module docs, and examples to use new snake_case API and adduct format, and document the new adduct model in the changelog, including migration guidance.

Tests:
- Update test suite to use the new function names and the simplified adduct API, removing references to the old adduct/charge signature.

Chores:
- Bump package version from 0.3.0 to 0.4.0 for the breaking API changes.