### PR TITLE
Refactor: Modularize codebase and fix Hill notation bug

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "IsotopicCalc"
 uuid = "5554e927-0bdd-4e37-b621-d0b49d571e7b"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Tomas Mikoviny <tomasmi@uio.no> and contributors"]
 
 [deps]

--- a/src/IsotopicCalc.jl
+++ b/src/IsotopicCalc.jl
@@ -52,12 +52,18 @@ See also: README.md for detailed examples and CITATION.bib for citing this packa
 """
 module IsotopicCalc
 
-    using JSON, Printf
+    using JSON
 
+    # Load element data that will be used by submodules
     const ELEMENTS = JSON.parsefile(Base.Filesystem.joinpath(dirname(@__FILE__),"elements.json"));
 
-    include("isotopicPattern.jl")
-    include("findFormula.jl")
+    # Include and load submodules
+    include("IsotopicPattern.jl")
+    include("FindFormula.jl")
+
+    # Import and re-export functions from submodules
+    using .IsotopicPatternModule: isotopic_pattern, monoisotopic_mass, isotopic_pattern_protonated, monoisotopic_mass_protonated
+    using .FindFormulaModule: Compound, find_formula
 
     export isotopic_pattern, monoisotopic_mass, isotopic_pattern_protonated, monoisotopic_mass_protonated, find_formula, Compound
 

--- a/src/IsotopicPattern.jl
+++ b/src/IsotopicPattern.jl
@@ -1,3 +1,10 @@
+module IsotopicPatternModule
+
+using Printf
+
+# Access ELEMENTS from parent module
+const ELEMENTS = isdefined(parentmodule(@__MODULE__), :ELEMENTS) ? parentmodule(@__MODULE__).ELEMENTS : Dict()
+
 # Pre-compiled regex patterns for better performance
 const FORMULA_VALIDATION_REGEX = r"^[A-Za-z\[\]\d\(\)]+$"
 const CHARGE_PATTERN_REGEX = r"\((\d+)([+-])\)"
@@ -589,3 +596,7 @@ julia> monoisotopic_mass_protonated("C6H12O6")
 See also: [`monoisotopic_mass`](@ref), [`isotopic_pattern_protonated`](@ref)
 """
 monoisotopic_mass_protonated(x) = isotopic_pattern(x; adduct="H+", print=false)[1][1]
+
+export isotopic_pattern, monoisotopic_mass, isotopic_pattern_protonated, monoisotopic_mass_protonated
+
+end # module IsotopicPatternModule


### PR DESCRIPTION
## Bug Fixes
- Fix Hill notation for non-carbon formulas: hydrogen atoms now correctly included in formula strings (e.g., HO2, H3NO, H2O instead of O2, NO)
- Hill notation now follows proper convention:
  * With carbon: C first, H second, then others alphabetically
  * Without carbon: All elements alphabetically (including H)

## Features
- Add "+" adduct for radical cation [M]+• (electron ionization)
- Update documentation with new adduct type and examples

## Refactoring
- Convert source files to proper module structure:
  * src/isotopicPattern.jl → src/IsotopicPattern.jl (IsotopicPatternModule)
  * src/findFormula.jl → src/FindFormula.jl (FindFormulaModule)
- Rename files to PascalCase following Julia conventions
- Add explicit module exports and imports
- Improve code organization and maintainability
- ELEMENTS constant shared from parent module to submodules

## Benefits
- Better encapsulation and namespace isolation
- Easier independent testing of modules
- Clearer dependencies and exports
- Maintains full backward compatibility

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Modularize the isotopic calculation codebase and extend formula search and adduct handling while preserving the public API.

New Features:
- Add support for the radical cation adduct "+" ([M]+•) in formula finding, including usage examples in the public API docs for `find_formula`.

Bug Fixes:
- Correct Hill notation generation so that non‑carbon formulas include hydrogen and all elements are ordered according to the Hill convention, both with and without carbon present.

Enhancements:
- Split core functionality into `IsotopicPatternModule` and `FindFormulaModule` submodules with explicit exports and imports for clearer structure and encapsulation.
- Share the ELEMENTS constant from the parent `IsotopicCalc` module into submodules instead of duplicating element data.
- Re-export key functions and types from the top-level `IsotopicCalc` module to maintain backward-compatible public APIs.

Build:
- Bump the package version from 0.4.0 to 0.5.0 to reflect the new modular structure and feature additions.