### PR TITLE
Fix robustness issues and refactor Hill notation

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "IsotopicCalc"
 uuid = "5554e927-0bdd-4e37-b621-d0b49d571e7b"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["Tomas Mikoviny <tomasmi@uio.no> and contributors"]
 
 [deps]

--- a/src/IsotopicPattern.jl
+++ b/src/IsotopicPattern.jl
@@ -3,7 +3,11 @@ module IsotopicPatternModule
 using Printf
 
 # Access ELEMENTS from parent module
-const ELEMENTS = isdefined(parentmodule(@__MODULE__), :ELEMENTS) ? parentmodule(@__MODULE__).ELEMENTS : Dict()
+const ELEMENTS = if isdefined(parentmodule(@__MODULE__), :ELEMENTS)
+    parentmodule(@__MODULE__).ELEMENTS
+else
+    error("ELEMENTS constant not found in parent module. Ensure IsotopicCalc is properly initialized with elements.json data.")
+end
 
 # Pre-compiled regex patterns for better performance
 const FORMULA_VALIDATION_REGEX = r"^[A-Za-z\[\]\d\(\)]+$"


### PR DESCRIPTION
- ELEMENTS initialization now throws explicit error instead of silent fallback to empty Dict(), preventing wrong results from misconfiguration
- Clarified adduct '+' documentation: electron mass correction (0.0005485 amu) is applied during m/z calculation, not in ADDUCTS constant
- Refactored Hill notation logic into build_hill_notation() helper function to reduce code duplication and improve maintainability
- Bumped version to 0.5.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Improve robustness of element data access and refactor formula generation to use a reusable Hill notation helper.

Bug Fixes:
- Fail fast with an explicit error when ELEMENTS is missing in submodules instead of silently falling back to an empty dictionary.

Enhancements:
- Extract Hill notation formula construction into a dedicated build_hill_notation() helper and reuse it in formula generation.

Build:
- Bump IsotopicCalc package version from 0.5.0 to 0.5.1.

Documentation:
- Clarify adduct documentation to explain that electron mass corrections are applied during m/z calculation rather than in the ADDUCTS constants.