### PR TITLE
Musing hawking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,48 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.0] - 2025-12-13
+
+### Added
+
+#### Flexible Adduct System
+- **Dynamic adduct parsing**: Replace hardcoded adduct dictionary with flexible `parse_adduct()` function
+- **Support for all periodic table elements**: Use any element (H, Na, K, Ca, Mg, Li, Br, Cl, etc.) in adduct notation
+- **Flexible notation format**: `[n]Element+/-[m]` where n=atom count, m=charge (both optional)
+- **Examples**: `"H+"`, `"Na+"`, `"Ca+"`, `"Mg+"`, `"Li+"`, `"Br-"`, `"Cl-"`
+
+#### Multiple Charge Support
+- **Multiply charged ions**: Support for ESI-MS and peptide analysis with multiple charges
+- **Notation**: `"2H+2"` (doubly protonated), `"3H+3"` (triply charged), etc.
+- **Radical ions**: `"+2"`, `"+3"`, `"-2"`, etc. for multiply charged radical ions
+- **Proper display formatting**: Shows `[M+2H]2+`, `[M]3+`, `[M+3H]3+`, etc.
+- **Distinction**: Clear difference between `"2H+"` (2 protons, charge +1) and `"2H+2"` (2 protons, charge +2)
+
+#### Type Flexibility
+- **Integer support**: Changed `mz_input` parameter from `Float64` to `Real`
+- **Improved UX**: Accept both integers (e.g., `33`) and floats (e.g., `33.0`)
+
+### Changed
+- Backward compatible: `get_adduct_info()` function now wraps `parse_adduct()`
+- Enhanced documentation with comprehensive examples for new adduct notation
+- Updated README with flexible adduct system description
+
+### Examples
+```julia
+# New flexible adduct support
+find_formula(60.0; adduct="Ca+")      # Calcium adduct
+find_formula(65.0; adduct="Li+")      # Lithium adduct
+find_formula(94.0; adduct="Cl-")      # Chloride loss
+
+# Multiple charge support
+find_formula(30.0; adduct="2H+2")     # Doubly protonated
+find_formula(20.0; adduct="3H+3")     # Triply protonated
+find_formula(29.0; adduct="+2")       # Radical dication
+
+# Integer input
+find_formula(33; adduct="H+")         # Works with integers
+```
+
 ## [0.5.0] - 2025-12-13
 
 ### Breaking Changes

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "IsotopicCalc"
 uuid = "5554e927-0bdd-4e37-b621-d0b49d571e7b"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Tomas Mikoviny <tomasmi@uio.no> and contributors"]
 
 [deps]

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ Matching formulas:
 
 The function has several keyword arguments used to customize the output.
 ```julia
-find_formula(mz_input::Float64;
+find_formula(mz_input::Real;
             atom_pool::Dict{String, Int}=Dict("C"=>20, "H"=>100, "O"=>10, "N"=>10),
             tolerance_ppm::Number=100,
             adduct::String=""
@@ -159,7 +159,12 @@ find_formula(mz_input::Float64;
 ```
 By default algorithm searches within an interval of 100 ppm around monoisotopic mass and takes into consideration C, H, O, N to be possible building atoms. The associated numbers mean maximum amount of respective atoms to be considered.
 
-Supported adducts include `H+`, `Na+`, `K+`, `H-`, or `""` for neutral molecules. The adduct string now contains both the mass change and charge information, making the API cleaner and more intuitive.
+The adduct parameter supports flexible notation using any element from the periodic table:
+- Format: `[n]Element+/-[m]` where n is optional atom count, m is optional charge
+- Any element is supported (e.g., `"Ca+"`, `"Mg+"`, `"Br-"`, `"Li+"`)
+- Multiple charges supported for multiply charged ions (e.g., `"2H+2"`, `"3H+3"`)
+- Special forms: `"+n"` (radical cation), `"-n"` (radical anion), `""` (neutral)
+- Examples: `"H+"` (singly charged), `"2H+2"` (doubly charged), `"+2"` (radical dication)
 
 ```julia
 julia> find_formula(59.0491; adduct="H+");

--- a/RELEASE_NOTES_v0.6.0.md
+++ b/RELEASE_NOTES_v0.6.0.md
@@ -1,0 +1,202 @@
+# IsotopicCalc.jl v0.6.0 Release Notes
+
+We're excited to announce **IsotopicCalc.jl v0.6.0**, featuring a major enhancement to the adduct system with flexible parsing and multiple charge support!
+
+## 🎯 Highlights
+
+### 1. Flexible Adduct System - Use Any Element! 🧪
+
+The adduct system has been completely redesigned to support **any element from the periodic table**, not just the hardcoded H, Na, and K.
+
+**Before (v0.5.0):**
+```julia
+# Only supported: H+, Na+, K+, H-, +, ""
+find_formula(59.0491; adduct="H+")
+find_formula(81.0284; adduct="Na+")
+```
+
+**Now (v0.6.0):**
+```julia
+# Use ANY element!
+find_formula(99.0; adduct="Ca+")   # Calcium
+find_formula(65.0; adduct="Li+")   # Lithium
+find_formula(82.0; adduct="Mg+")   # Magnesium
+find_formula(94.0; adduct="Cl-")   # Chloride loss
+find_formula(100.0; adduct="Br-")  # Bromide loss
+```
+
+### 2. Multiple Charge Support ⚡⚡⚡
+
+Critical for ESI-MS and peptide analysis! Now you can specify multiply charged ions.
+
+**New Notation:** `[n]Element+/-[m]`
+- `n` = number of atoms (optional, defaults to 1)
+- `m` = charge state (optional, defaults to 1)
+
+**Examples:**
+```julia
+# Doubly protonated (common in ESI-MS)
+find_formula(30.0; adduct="2H+2")
+# Output: C3H6O  [M+2H]2+  m/z: 30.028037
+
+# Triply protonated (peptides)
+find_formula(20.0; adduct="3H+3")
+# Output: C2H3NO  [M+3H]3+  m/z: 20.014431
+
+# Radical dication
+find_formula(29.0; adduct="+2")
+# Output: C2H2O2  [M]2+  m/z: 29.002191
+
+# Radical trication
+find_formula(19.5; adduct="+3")
+```
+
+### 3. Important Distinction: Atoms vs. Charge
+
+Understanding the difference between atom count and charge state:
+
+```julia
+# "2H+" = 2 protons added, charge state +1
+find_formula(60.0; adduct="2H+")
+# m/z = (M + 2×1.008) / 1 = M + 2.016
+
+# "2H+2" = 2 protons added, charge state +2
+find_formula(30.0; adduct="2H+2")
+# m/z = (M + 2×1.008) / 2 = (M + 2.016) / 2
+```
+
+### 4. Type Flexibility
+
+No more type errors with integer inputs!
+
+```julia
+# Both work now
+find_formula(33; adduct="H+")      # Integer ✓
+find_formula(33.0; adduct="H+")    # Float ✓
+```
+
+## 📋 Complete Adduct Notation Reference
+
+### Format
+```
+[n]Element+/-[m]
+```
+
+### Single Charge Examples
+| Notation | Description | Display |
+|----------|-------------|---------|
+| `"H+"` | Protonated | `[M+H]+` |
+| `"Na+"` | Sodium adduct | `[M+Na]+` |
+| `"K+"` | Potassium adduct | `[M+K]+` |
+| `"Ca+"` | Calcium adduct | `[M+Ca]+` |
+| `"2H+"` | Two protons, charge +1 | `[M+2H]+` |
+| `"H-"` | Deprotonated | `[M-H]-` |
+| `"Cl-"` | Chloride loss | `[M-Cl]-` |
+| `"+"` | Radical cation | `[M]+` |
+| `""` | Neutral | (no adduct) |
+
+### Multiple Charge Examples
+| Notation | Description | Display |
+|----------|-------------|---------|
+| `"2H+2"` | Doubly protonated | `[M+2H]2+` |
+| `"3H+3"` | Triply protonated | `[M+3H]3+` |
+| `"4H+4"` | Quadruply protonated | `[M+4H]4+` |
+| `"+2"` | Radical dication | `[M]2+` |
+| `"+3"` | Radical trication | `[M]3+` |
+| `"-2"` | Radical dianion | `[M]2-` |
+| `"2H-2"` | Double deprotonation | `[M-2H]2-` |
+
+## 🔬 Real-World Applications
+
+### Peptide Analysis
+```julia
+# Typical peptide with MW ~600 Da
+# Doubly charged: m/z ≈ 301
+find_formula(301.0; adduct="2H+2", atom_pool=Dict(
+    "C"=>50, "H"=>100, "N"=>20, "O"=>20, "S"=>2
+))
+
+# Triply charged: m/z ≈ 201
+find_formula(201.0; adduct="3H+3", atom_pool=Dict(
+    "C"=>50, "H"=>100, "N"=>20, "O"=>20, "S"=>2
+))
+```
+
+### Metal Adducts
+```julia
+# Lithium adducts (common in MALDI)
+find_formula(65.0; adduct="Li+")
+
+# Calcium adducts (biological samples)
+find_formula(99.0; adduct="Ca+")
+
+# Magnesium adducts
+find_formula(82.0; adduct="Mg+")
+```
+
+### Halogen Loss
+```julia
+# Chlorine loss (organochlorines)
+find_formula(94.0; adduct="Cl-")
+
+# Bromine loss (organobromines)
+find_formula(100.0; adduct="Br-")
+```
+
+## 🔧 Technical Details
+
+### Implementation
+- **Dynamic parsing**: Replaced hardcoded `ADDUCTS` dictionary with `parse_adduct()` function
+- **Element validation**: Automatically validates against all elements in the periodic table
+- **Regex pattern matching**: `^(\d*)([A-Z][a-z]?)([+-])(\d*)$` for flexible parsing
+- **Backward compatible**: Old `get_adduct_info()` function still works via wrapper
+
+### m/z Calculation
+The m/z calculation correctly handles multiple charges:
+
+```julia
+M = neutral_mass + adduct_mass - charge × 0.0005485  # electron mass correction
+m/z = charge == 0 ? M : M / abs(charge)
+```
+
+### Display Formatting
+- Single charge: `[M+H]+`, `[M+Na]+`
+- Multiple charges: `[M+2H]2+`, `[M+3H]3+`, `[M]2+`
+- Proper superscript notation in output
+
+## 📦 Upgrading
+
+### From v0.5.0
+No breaking changes! All existing code continues to work:
+
+```julia
+# Still works exactly as before
+find_formula(59.0491; adduct="H+")
+find_formula(81.0284; adduct="Na+")
+find_formula(58.0419; adduct="+")
+```
+
+### Installation
+```julia
+using Pkg
+Pkg.update("IsotopicCalc")
+```
+
+## 🐛 Bug Fixes
+- Fixed JSON.Object type compatibility issue with SubString keys
+- Improved error messages for invalid adduct formats
+
+## 📚 Documentation
+- Comprehensive docstrings with examples
+- Updated README with new notation
+- Added CHANGELOG entry with migration guide
+
+## 🙏 Acknowledgments
+
+This release brings IsotopicCalc.jl's adduct system to a new level of flexibility, making it suitable for a much wider range of mass spectrometry applications including ESI-MS, MALDI-TOF, and peptide/protein analysis.
+
+---
+
+**Full Changelog**: [v0.5.0...v0.6.0](https://github.com/slowbrain/IsotopicCalc.jl/compare/v0.5.0...v0.6.0)
+
+**Questions or Issues?** Please open an issue on [GitHub](https://github.com/slowbrain/IsotopicCalc.jl/issues)

--- a/src/FindFormula.jl
+++ b/src/FindFormula.jl
@@ -56,59 +56,107 @@ struct AdductInfo
 end
 
 """
-Dictionary of common mass spectrometry adducts.
+    parse_adduct(adduct::String) -> AdductInfo
 
-# Supported Adducts
-- "H+": Protonated [M+H]+ (+1.00783 amu, charge +1)
-- "Na+": Sodium adduct [M+Na]+ (+22.98977 amu, charge +1)
-- "K+": Potassium adduct [M+K]+ (+38.96371 amu, charge +1)
-- "H-": Deprotonated [M-H]- (-1.00783 amu, charge -1)
-- "+": Radical cation [M]+• (charge +1, electron mass correction applied during calculation)
-- "": Neutral molecule (0 amu, charge 0)
+Parse an adduct string and return adduct information.
 
-# Notes
-For charged species, electron mass correction (-0.0005485 amu per positive charge,
-+0.0005485 amu per negative charge) is automatically applied during m/z calculation.
-The radical cation "+" has no additional mass shift beyond the electron correction.
-"""
-const ADDUCTS = Dict(
-    "H+" => AdductInfo(1.00782503223, 1, "M+H"),
-    "Na+" => AdductInfo(22.989769282, 1, "M+Na"),
-    "K+" => AdductInfo(38.9637064864, 1, "M+K"),
-    "H-" => AdductInfo(-1.00782503223, -1, "M-H"),
-    "+" => AdductInfo(0.0, 1, "M"),
-    "" => AdductInfo(0.0, 0, "")
-)
+Supports flexible adduct notation using any element from the periodic table,
+including multiple charges for multiply charged ions.
 
-"""
-    get_adduct_info(adduct::String) -> AdductInfo
-
-Get adduct information from an adduct string.
+# Supported Formats
+- "Element+": Addition with positive charge (e.g., "H+", "Na+", "K+", "Ca+")
+- "Element-": Removal with negative charge (e.g., "H-", "Cl-")
+- "nElement+": Multiple atoms, single charge (e.g., "2H+", "3Na+")
+- "nElement+m": Multiple atoms, multiple charges (e.g., "2H+2", "3H+3")
+- "+n": Radical cation with charge +n (e.g., "+", "+2", "+3")
+- "-n": Radical anion with charge -n (e.g., "-", "-2", "-3")
+- "": Neutral molecule (charge 0, no mass change)
 
 # Arguments
-- `adduct::String`: Adduct identifier (e.g., "H+", "Na+", "K+", "H-", or "")
+- `adduct::String`: Adduct identifier in the formats above
 
 # Returns
-- `AdductInfo`: Struct containing mass, charge, and display name
+- `AdductInfo`: Struct containing mass change, charge, and display name
 
 # Throws
-- `ArgumentError`: If the adduct string is not recognized
+- `ArgumentError`: If the adduct format is invalid or element not found
 
 # Examples
 ```julia
-julia> get_adduct_info("H+")
+julia> parse_adduct("H+")
 AdductInfo(1.00782503223, 1, "M+H")
 
-julia> get_adduct_info("Na+")
-AdductInfo(22.989769282, 1, "M+Na")
+julia> parse_adduct("2H+2")
+AdductInfo(2.01565006446, 2, "M+2H")
+
+julia> parse_adduct("3H+3")
+AdductInfo(3.02347509669, 3, "M+3H")
+
+julia> parse_adduct("+2")
+AdductInfo(0.0, 2, "M")
+
+julia> parse_adduct("Ca+")
+AdductInfo(39.962590863, 1, "M+Ca")
 ```
 """
-function get_adduct_info(adduct::String)
-    if !haskey(ADDUCTS, adduct)
-        valid_adducts = join(sort(["\"$k\"" for k in keys(ADDUCTS)]), ", ")
-        throw(ArgumentError("Unknown adduct '$adduct'. Supported adducts: $valid_adducts"))
+function parse_adduct(adduct::String)
+    # Handle special cases for neutral
+    if adduct == ""
+        return AdductInfo(0.0, 0, "")
     end
-    return ADDUCTS[adduct]
+
+    # Handle special cases for radical ions: "+", "+2", "+3", "-", "-2", "-3"
+    m_radical = match(r"^([+-])(\d*)$", adduct)
+    if m_radical !== nothing
+        charge_sign, charge_num_str = m_radical.captures
+        charge_magnitude = charge_num_str == "" ? 1 : parse(Int, charge_num_str)
+        charge = charge_sign == "+" ? charge_magnitude : -charge_magnitude
+        display_name = "M"  # Just "M" for radical ions, charge will be added in output formatting
+        return AdductInfo(0.0, charge, display_name)
+    end
+
+    # Parse format: [atom_count]Element[+|-][charge_count]
+    # Match pattern: optional number, element symbol, +/-, optional number
+    m = match(r"^(\d*)([A-Z][a-z]?)([+-])(\d*)$", adduct)
+
+    if m === nothing
+        throw(ArgumentError("Invalid adduct format '$adduct'. Expected format: [n]Element+/-[m] (e.g., 'H+', '2H+2', 'Cl-') or special forms '+n', '-n', ''"))
+    end
+
+    atom_count_str, element, charge_sign, charge_count_str = m.captures
+
+    # Parse atom count (default to 1 if not specified)
+    atom_count = atom_count_str == "" ? 1 : parse(Int, atom_count_str)
+
+    # Parse charge count (default to 1 if not specified)
+    charge_magnitude = charge_count_str == "" ? 1 : parse(Int, charge_count_str)
+
+    # Convert SubString to String for JSON.Object compatibility
+    element = String(element)
+
+    # Check if element exists
+    if !haskey(ELEMENTS, element)
+        available_elements = join(sort(collect(keys(ELEMENTS)))[1:min(20, length(ELEMENTS))], ", ")
+        throw(ArgumentError("Unknown element '$element'. First 20 available elements: $available_elements, ..."))
+    end
+
+    # Get element mass
+    element_mass = ELEMENTS[element]["Relative Atomic Mass"][1]
+
+    # Calculate total mass change and charge
+    charge = charge_sign == "+" ? charge_magnitude : -charge_magnitude
+    mass_change = charge_sign == "+" ? atom_count * element_mass : -atom_count * element_mass
+
+    # Create display name
+    atom_count_display = atom_count == 1 ? "" : string(atom_count)
+    display_name = "M$(charge_sign)$(atom_count_display)$(element)"
+
+    return AdductInfo(mass_change, charge, display_name)
+end
+
+# Keep get_adduct_info for backward compatibility, but make it use parse_adduct
+function get_adduct_info(adduct::String)
+    return parse_adduct(adduct)
 end
 
 """
@@ -173,14 +221,14 @@ Uses combinatorial search with chemical heuristics to enumerate formulas.
 Currently applies H ≥ 0.5×C rule to reduce search space.
 
 # Arguments
-- `mz_input::Float64`: Target m/z value
+- `mz_input::Real`: Target m/z value
 - `atom_pool::Dict{String, Int}`: Maximum atom counts per element
 - `adduct_info::AdductInfo`: Adduct information (mass, charge, name)
 
 # Returns
 - `Vector{Compound}`: All generated formulas (before tolerance filtering)
 """
-function generate_formulas(mz_input::Float64, atom_pool::Dict{String, Int}, adduct_info::AdductInfo)
+function generate_formulas(mz_input::Real, atom_pool::Dict{String, Int}, adduct_info::AdductInfo)
     formulas = Compound[]  # Type-stable array initialization
     adduct_mass = adduct_info.mass
     charge = adduct_info.charge
@@ -268,7 +316,7 @@ function filter_formulas(formulas, mz_input, tolerance)
 end
 
 """
-    find_formula(mz_input::Float64; tolerance_ppm=100, atom_pool=Dict("C"=>20, "H"=>100, "O"=>10, "N"=>10), adduct="")
+    find_formula(mz_input::Real; tolerance_ppm=100, atom_pool=Dict("C"=>20, "H"=>100, "O"=>10, "N"=>10), adduct="")
 
 Find possible molecular formulas matching an experimental m/z value.
 
@@ -277,17 +325,26 @@ to find formulas that match the input mass within a specified tolerance. Results
 sorted by mass accuracy (ppm error).
 
 # Arguments
-- `mz_input::Float64`: Experimental m/z value to match
+- `mz_input::Real`: Experimental m/z value to match (can be Integer or Float)
 - `tolerance_ppm::Number=100`: Mass tolerance in parts per million (default: 100 ppm)
 - `atom_pool::Dict{String, Int}=Dict("C"=>20, "H"=>100, "O"=>10, "N"=>10)`:
   Dictionary specifying maximum atom counts for each element to consider
-- `adduct::String=""`: Adduct type - one of "H+", "Na+", "K+", "H-", "+", or "" for neutral
-  - "H+": Protonated [M+H]+ (charge +1)
-  - "Na+": Sodium adduct [M+Na]+ (charge +1)
-  - "K+": Potassium adduct [M+K]+ (charge +1)
-  - "H-": Deprotonated [M-H]- (charge -1)
-  - "+": Radical cation [M]+• (charge +1, electron ionization)
-  - "": Neutral molecule (charge 0)
+- `adduct::String=""`: Adduct type using flexible notation:
+  - Format: `[n]Element+/-[m]` where n=atom count (optional), m=charge (optional)
+  - Any element from the periodic table is supported (e.g., "Ca+", "Mg+", "Br-")
+  - Multiple charges supported for multiply charged ions (e.g., "2H+2", "3H+3")
+  - Special forms: "+n" (radical cation), "-n" (radical anion), "" (neutral)
+  - Common examples:
+    - "H+": Protonated [M+H]+ (charge +1)
+    - "2H+2": Doubly protonated [M+2H]2+ (charge +2)
+    - "3H+3": Triply protonated [M+3H]3+ (charge +3)
+    - "Na+": Sodium adduct [M+Na]+ (charge +1)
+    - "K+": Potassium adduct [M+K]+ (charge +1)
+    - "2H+": Two protons added [M+2H]+ (charge +1, different from 2H+2!)
+    - "H-": Deprotonated [M-H]- (charge -1)
+    - "+2": Doubly charged radical cation [M]2+ (charge +2)
+    - "+": Radical cation [M]+• (charge +1, electron ionization)
+    - "": Neutral molecule (charge 0)
 
 # Returns
 - `Vector{Compound}`: Array of matching formulas sorted by ppm error (best matches first)
@@ -310,6 +367,11 @@ julia> find_formula(58.0419; adduct="+")
 Matching formulas:
  C3H6O  [M]+  m/z: 58.041316  ppm: 1.01
 
+julia> # Multiply charged ions (e.g., for peptides)
+julia> find_formula(30.0; adduct="2H+2")  # Doubly protonated
+Matching formulas:
+ C3H6O  [M+2H]2+  m/z: 30.028037  ppm: -...
+
 julia> # Custom atom pool for peptide search
 julia> find_formula(150.05; adduct="H+", atom_pool=Dict("C"=>10, "H"=>20, "N"=>5, "O"=>5, "S"=>2))
 ```
@@ -328,7 +390,7 @@ julia> find_formula(150.05; adduct="H+", atom_pool=Dict("C"=>10, "H"=>20, "N"=>5
 
 See also: [`isotopic_pattern`](@ref), [`monoisotopic_mass`](@ref), [`Compound`](@ref)
 """
-function find_formula(mz_input::Float64; tolerance_ppm::Number=100, atom_pool::Dict{String, Int}=Dict("C"=>20, "H"=>100, "O"=>10, "N"=>10), adduct::String="")
+function find_formula(mz_input::Real; tolerance_ppm::Number=100, atom_pool::Dict{String, Int}=Dict("C"=>20, "H"=>100, "O"=>10, "N"=>10), adduct::String="")
     adduct_info = get_adduct_info(adduct)
     formulas = generate_formulas(mz_input, atom_pool, adduct_info)
     matching_formulas = filter_formulas(formulas, mz_input, tolerance_ppm)
@@ -338,8 +400,13 @@ function find_formula(mz_input::Float64; tolerance_ppm::Number=100, atom_pool::D
 
     println("Matching formulas:")
     for compound in matching_formulas
+        charge_abs = abs(adduct_info.charge)
         charge_sign = adduct_info.charge > 0 ? "+" : (adduct_info.charge < 0 ? "-" : "")
-        adduct_string = adduct_info.name == "" ? charge_sign : "\t[" * adduct_info.name * "]" * charge_sign
+
+        # Format charge suffix: +, 2+, 3+, etc.
+        charge_suffix = charge_abs == 0 ? "" : (charge_abs == 1 ? charge_sign : string(charge_abs) * charge_sign)
+
+        adduct_string = adduct_info.name == "" ? charge_suffix : "\t[" * adduct_info.name * "]" * charge_suffix
         println(" ", compound.formula, adduct_string, "\tm/z: ", string(round(compound.mz, digits=6)), "\tppm: ", string(round(compound.ppm, digits=2)))
     end
     return matching_formulas


### PR DESCRIPTION
## Summary by Sourcery

Introduce a flexible, element-agnostic adduct parsing and display system and make m/z input handling more type-generic.

New Features:
- Add a `parse_adduct` API that parses flexible adduct notation, including any periodic-table element, atom counts, and multi-charge states.
- Support radical cation/anion notation and multiply charged ions with appropriate display formatting in output.
- Allow `find_formula` and related functions to accept any `Real` m/z input, including integers.

Enhancements:
- Keep `get_adduct_info` as a backward-compatible wrapper around the new adduct parser.
- Improve printed output formatting for adducts to show correct charge multiplicity (e.g., `2+`, `3+`).
- Expand and clarify user-facing documentation and examples for the new adduct notation in docstrings, README, and changelog.

Build:
- Bump package version to 0.6.0 in `Project.toml`.

Documentation:
- Document the new flexible adduct system, multi-charge support, and Real-typed `mz_input` in README, CHANGELOG, and dedicated v0.6.0 release notes.